### PR TITLE
Allow host to override the mongo port

### DIFF
--- a/pack/commands.cfg
+++ b/pack/commands.cfg
@@ -3,49 +3,49 @@
 # Warn at 2s connection, crit at 4.
 define command {
     command_name    check_mongodb_connection
-    command_line    $PLUGINSDIR$/check_mongodb.py -D -H $HOSTADDRESS$ -P 27017 -A connect -W 2 -C 4
+    command_line    $PLUGINSDIR$/check_mongodb.py -D -H $HOSTADDRESS$ -P $_HOSTMONGOPORT$ -A connect -W 2 -C 4
 }
 
 
 # % of open connection
 define command {
     command_name    check_mongodb_open_connections
-    command_line    $PLUGINSDIR$/check_mongodb.py -D -H $HOSTADDRESS$ -P 27017 -A connections -W 70 -C 80
+    command_line    $PLUGINSDIR$/check_mongodb.py -D -H $HOSTADDRESS$ -P $_HOSTMONGOPORT$ -A connections -W 70 -C 80
 }
 
 
 # Replication lag. Warn at 15, crit at 30
 define command {
     command_name    check_mongodb_replication_lag
-    command_line    $PLUGINSDIR$/check_mongodb.py -D -H $HOSTADDRESS$ -P 27017 -A replication_lag -W 15 -C 30
+    command_line    $PLUGINSDIR$/check_mongodb.py -D -H $HOSTADDRESS$ -P $_HOSTMONGOPORT$ -A replication_lag -W 15 -C 30
 }
 
 
 # % time wher the db is lock
 define command {
     command_name    check_mongodb_lock_time
-    command_line    $PLUGINSDIR$/check_mongodb.py -D -H $HOSTADDRESS$ -P 27017 -A lock -W 5 -C 10
+    command_line    $PLUGINSDIR$/check_mongodb.py -D -H $HOSTADDRESS$ -P $_HOSTMONGOPORT$ -A lock -W 5 -C 10
 }
 
 
 # Average flush time, in ms
 define command {
     command_name    check_mongodb_flush_time
-    command_line    $PLUGINSDIR$/check_mongodb.py -D -H $HOSTADDRESS$ -P 27017 -A flushing -W 100 -C 200
+    command_line    $PLUGINSDIR$/check_mongodb.py -D -H $HOSTADDRESS$ -P $_HOSTMONGOPORT$ -A flushing -W 100 -C 200
 }
 
 
 # Lastf lush time in ms
 define command {
     command_name    check_mongodb_last_flush
-    command_line    $PLUGINSDIR$/check_mongodb.py -D -H $HOSTADDRESS$ -P 27017 -A last_flush_time -W 200 -C 400
+    command_line    $PLUGINSDIR$/check_mongodb.py -D -H $HOSTADDRESS$ -P $_HOSTMONGOPORT$ -A last_flush_time -W 200 -C 400
 }
 
 
 # Check the replicaset
 define command {
     command_name    check_mongodb_replicaset
-    command_line    $PLUGINSDIR$/check_mongodb.py -D -H $HOSTADDRESS$ -P 27017 -A replset_state
+    command_line    $PLUGINSDIR$/check_mongodb.py -D -H $HOSTADDRESS$ -P $_HOSTMONGOPORT$ -A replset_state
 }
 
 
@@ -53,5 +53,5 @@ define command {
 # Check the index miss ratio
 define command {
     command_name    check_mongodb_index_miss_ratio
-    command_line    $PLUGINSDIR$/check_mongodb.py -D -H $HOSTADDRESS$ -P 27017 -A index_miss_ratio -W .005 -C .01
+    command_line    $PLUGINSDIR$/check_mongodb.py -D -H $HOSTADDRESS$ -P $_HOSTMONGOPORT$ -A index_miss_ratio -W .005 -C .01
 }

--- a/pack/templates.cfg
+++ b/pack/templates.cfg
@@ -2,6 +2,7 @@
 define host{
     name          mongodb
     register      0
+    _MONGOPORT    27017
 }
 
 


### PR DESCRIPTION
When dealing with shard infrastructure it would be nice to allow the host to override the default port.

http://docs.mongodb.org/manual/reference/default-mongodb-port/
